### PR TITLE
Task/71  PlayerPageで再生中のみCodeMirrorのカーソルが表示されるようにした 

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,11 +57,11 @@ body {
   font-size: 2em !important;
 }
 
-#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
+#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
   visibility: visible !important;
 }
 
-#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
+#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
   animation: flash 1s linear infinite;
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -62,7 +62,9 @@ body {
   visibility: visible !important;
 }
 
-#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
+/* PlayerPageで再生中のみカーソルを点滅させるCSS */
+/* prettier-ignore */
+#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
   animation: flash 1s linear infinite;
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,13 +57,11 @@ body {
   font-size: 2em !important;
 }
 
-/* PlayerPageで常にカーソルを表示するCSS */
-#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
+/* PlayerPageで再生中のみカーソルを表示させるCSS */
+#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
   visibility: visible !important;
 }
 
-/* PlayerPageで再生中のみカーソルを点滅させるCSS */
-/* prettier-ignore */
 #player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
   animation: flash 1s linear infinite;
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,12 +57,12 @@ body {
   font-size: 2em !important;
 }
 
-/* PlayerPageのCodeMirrorで再生中のみカーソルを表示するCSS */
-#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
+/* PlayerPageで常にカーソルを表示するCSS */
+#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
   visibility: visible !important;
 }
 
-#player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
+#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
   animation: flash 1s linear infinite;
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,11 +57,11 @@ body {
   font-size: 2em !important;
 }
 
-.CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
+#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
   visibility: visible !important;
 }
 
-.CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
+#player-page .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
   animation: flash 1s linear infinite;
 }
 

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,6 +57,7 @@ body {
   font-size: 2em !important;
 }
 
+/* PlayerPageのCodeMirrorで再生中のみカーソルを表示するCSS */
 #player-page.is-play .CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
   visibility: visible !important;
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -56,4 +56,24 @@ body {
 .CodeMirror-hint {
   font-size: 2em !important;
 }
+
+.CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursors {
+  visibility: visible !important;
+}
+
+.CodeMirror:not(.CodeMirror-focused) .CodeMirror-cursor {
+  animation: flash 1s linear infinite;
+}
+
+@keyframes flash {
+  0%,
+  50% {
+    opacity: 1;
+  }
+
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
 </style>

--- a/front/src/CodingPlayer.ts
+++ b/front/src/CodingPlayer.ts
@@ -46,7 +46,6 @@ export class CodingPlayer {
     }
     editor.setOption('mode', language.tag)
     editor.setValue('')
-    editor.focus()
     this._stream = this._stream.toNormalization(500)
     this._info.totalTime = this._stream.videoInfo.recordingTime
     // 最初の要素を描画
@@ -104,7 +103,6 @@ export class CodingPlayer {
       throw new Error('video is not Load')
     }
     this.pause()
-    editor.focus()
     editor.setValue('')
     this._stream.reset()
     // 最初の要素を描画

--- a/front/src/views/PlayerPage.vue
+++ b/front/src/views/PlayerPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="player-page">
+  <div id="player-page" :class="{ 'is-play': player.isPlay }">
     <div id="side-panel">
       <h1>Player</h1>
       <input type="file" @change="loadData" value="読み込み" />

--- a/front/src/views/PlayerPage.vue
+++ b/front/src/views/PlayerPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="player-page" :class="{ 'is-play': player.isPlay }">
+  <div id="player-page">
     <div id="side-panel">
       <h1>Player</h1>
       <input type="file" @change="loadData" value="読み込み" />


### PR DESCRIPTION
EditorPageにまでカーソルを常に表示するとカーソルの主張が強すぎると感じたため、止めた